### PR TITLE
Fixing a random issue where a report html encoding fails

### DIFF
--- a/drfeedback.py
+++ b/drfeedback.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 #
 # drfeedback.py - Doctor Feedback

--- a/feedback_inspectors.py
+++ b/feedback_inspectors.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 #
 # feedback_inspector.py

--- a/feedback_presentation.py
+++ b/feedback_presentation.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 #
 # feedback_presentation.py

--- a/markup.py
+++ b/markup.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 # This code is in the public domain, it comes
 # with absolutely no warranty and you can do
 # absolutely whatever you want with it.

--- a/send_report.py
+++ b/send_report.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 #
 # send_report.py

--- a/wsgi_main.py
+++ b/wsgi_main.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 #
 # wsgi_main.py


### PR DESCRIPTION
 * The markup html hmtl_document() would fail with UnicodeDecodeError: 'ascii' codec can't decode byte
 * Resolved by forcing each module to encode strings in utf-8 instead