### PR TITLE
Fixing random error with unicode characters in logs

### DIFF
--- a/drfeedback.py
+++ b/drfeedback.py
@@ -69,8 +69,8 @@ def analyze(tarfilename, idname=None, full_dump=False):
 
     # complete the report and hand it over
     html_report.wrap_it_up()
-    hmtl_document = html_report.get_html()
-    return hmtl_document()
+    html_document = html_report.get_html()
+    return html_document()
 
 
 if __name__ == '__main__':

--- a/feedback_presentation.py
+++ b/feedback_presentation.py
@@ -18,6 +18,7 @@ import feedback_inspectors  # TODO: is this used?
 import markup
 import base64
 import time
+import cgi
 
 
 #
@@ -114,7 +115,12 @@ class FeedbackPresentation:
                 self.page.img(src='data:image/png;base64,%s' % img64)
                 pass
             else:
-                self.page.pre(''.join(log['logdata']), class_='logfile')
+                # Insert log lines, escaping non-ascii characters to HTML encoding
+                lines = []
+                for line in log['logdata']:
+                    lines.append (cgi.escape(unicode(line, errors='ignore')).encode('ascii', 'xmlcharrefreplace'))
+
+                self.page.pre(lines, class_='logfile')
 
             self.page.div.close()
             self.page.div.close()


### PR DESCRIPTION
 * occassionally if the logs contain non-ascii codes such as (r) or (c)
   the parser would break with an exception. This changeset should fix that.