### PR TITLE
[OS-915] Added data from real server with mangled numbers that force a spike

### DIFF
--- a/monitor/tests/data/log_real_data.txt
+++ b/monitor/tests/data/log_real_data.txt
@@ -1,0 +1,6 @@
+date=25-04-2019 total-logs=1369
+date=25-04-2019 total-logs=1370
+date=25-04-2019 total-logs=1370
+date=25-04-2019 total-logs=1370
+date=25-04-2019 total-logs=18370
+date=26-04-2019 total-logs=15434

--- a/monitor/tests/test_monitor.py
+++ b/monitor/tests/test_monitor.py
@@ -43,6 +43,10 @@ def test_steady_five_days():
     rc = os.system(cmdline('log_sample_steady.txt', 5, 1.5))
     assert os.WEXITSTATUS(rc) == 0
 
+def test_spike_real_log():
+    rc = os.system(cmdline('log_real_data.txt', 2, 1.5))
+    assert os.WEXITSTATUS(rc) == 1
+
 def test_alert():
     alert_message = 'Slack alert signal requested, simulate=True'
     command_line = cmdline('log_sample_spike.txt', 5, 1.1)


### PR DESCRIPTION
This PR simply adds a new test with data from real server.
The last 2 samples have been manually raised to force a spike.
The alert has been tested correctly on the server.
